### PR TITLE
Enhance user import functionality and service provider command publishing

### DIFF
--- a/src/Actions/UserImportAction.php
+++ b/src/Actions/UserImportAction.php
@@ -10,14 +10,22 @@ use Illuminate\Support\Collection;
 
 class UserImportAction
 {
-    public function execute(Collection $users): void
+    private int $success = 0;
+
+    private int $failures = 0;
+
+    public function execute(Collection $users): array
     {
 
         $users->chunk(500)->each(function ($usersChunk): void {
             $bento = new BentoConnector;
             $request = new ImportSubscribers($usersChunk);
-            $bento->send($request);
+            $importResult = $bento->send($request);
+            $this->success = +$importResult->json()['results'];
+            $this->failures = +$importResult->json()['failed'];
         });
+
+        return ['results' => $this->success, 'failed' => $this->failures];
 
     }
 }

--- a/src/BentoLaravelServiceProvider.php
+++ b/src/BentoLaravelServiceProvider.php
@@ -2,7 +2,6 @@
 
 namespace Bentonow\BentoLaravel;
 
-use Bentonow\BentoLaravel\Console\InstallCommand;
 use Illuminate\Support\Facades\Mail;
 use Illuminate\Support\ServiceProvider;
 

--- a/src/BentoLaravelServiceProvider.php
+++ b/src/BentoLaravelServiceProvider.php
@@ -11,18 +11,32 @@ class BentoLaravelServiceProvider extends ServiceProvider
     public function boot(): void
     {
         if ($this->app->runningInConsole()) {
-            $this->commands([
-                InstallCommand::class,
-            ]);
 
             $this->publishes([
                 __DIR__.'/../config/bentonow.php' => config_path('bentonow.php'),
             ], 'bentonow');
         }
 
+        $this->registerCommands();
+
         Mail::extend('bento', function (array $config = []) {
             return new BentoTransport;
         });
+    }
+
+    /**
+     * Register the package's commands.
+     *
+     * @return void
+     */
+    protected function registerCommands()
+    {
+        if ($this->app->runningInConsole()) {
+            $this->commands([
+                Console\UserImportCommand::class,
+                Console\InstallCommand::class,
+            ]);
+        }
     }
 
     public function register(): void

--- a/src/Console/UserImportCommand.php
+++ b/src/Console/UserImportCommand.php
@@ -16,31 +16,36 @@ class UserImportCommand extends Command
 
     protected $name = 'bento:import-users';
 
+    private int $success = 0;
+    private int $failures = 0;
+
     public function handle(): int
     {
         $users = User::select('name', 'email')->get();
         $users->chunk(500)->each(function ($chunk): void {
-            (UserImportAction::class)->execute(
+            $importResult = (new UserImportAction)->execute(
                 $chunk->map(function ($user) {
-                    return [
-                        new ImportSubscribersData(
-                            email: $user->email,
-                            firstName: Str::of($user->name)
-                                ->after('.')
-                                ->before(' ')
-                                ->__toString(),
-                            lastName: Str::of($user->name)
-                                ->after(' ')
-                                ->__toString(),
-                            tags: ['onboarding_complete'],
-                            removeTags: null,
-                            fields: ['imported_at' => now()]
-                        ),
-                    ];
+                    return new ImportSubscribersData(
+                        email: $user->email,
+                        firstName: Str::of($user->name)
+                            ->after('.')
+                            ->before(' ')
+                            ->__toString(),
+                        lastName: Str::of($user->name)
+                            ->after(' ')
+                            ->__toString(),
+                        tags: ['onboarding_complete'],
+                        removeTags: null,
+                        fields: ['imported_at' => now()]
+                    );
+
                 })
             );
+            $this->success = +$importResult['results'];
+            $this->failures = +$importResult['failed'];
         });
 
+        $this->info("Successfully imported {$this->success} users. Failed to import {$this->failures} users.");
         return self::SUCCESS;
     }
 }

--- a/src/Console/UserImportCommand.php
+++ b/src/Console/UserImportCommand.php
@@ -17,6 +17,7 @@ class UserImportCommand extends Command
     protected $name = 'bento:import-users';
 
     private int $success = 0;
+
     private int $failures = 0;
 
     public function handle(): int
@@ -46,6 +47,7 @@ class UserImportCommand extends Command
         });
 
         $this->info("Successfully imported {$this->success} users. Failed to import {$this->failures} users.");
+
         return self::SUCCESS;
     }
 }

--- a/src/DataTransferObjects/ImportSubscribersData.php
+++ b/src/DataTransferObjects/ImportSubscribersData.php
@@ -21,8 +21,8 @@ class ImportSubscribersData
             'email' => $this->email,
             'first_name' => $this->firstName,
             'last_name' => $this->lastName,
-            'tags' => implode(',', $this->tags),
-            'remove_tags' => implode(',', $this->removeTags),
-        ], $this->fields));
+            'tags' => ! empty($this->tags) ? implode(',', $this->tags) : null,
+            'remove_tags' => ! empty($this->removeTags) ? implode(',', $this->removeTags) : null,
+        ], $this->fields ?? []));
     }
 }

--- a/src/Requests/ImportSubscribers.php
+++ b/src/Requests/ImportSubscribers.php
@@ -26,7 +26,6 @@ class ImportSubscribers extends Request implements HasBody
 
     protected function defaultBody(): array
     {
-
         return [
             'subscribers' => $this->subscriberCollection->map(fn ($subscriber) => $subscriber->__toArray()),
         ];


### PR DESCRIPTION
fix: Updated the Service provider to publish all commands to artisan without having to complete the install.

feat: Added in support for massive user imports, with chunking of 500 records per API call to bento.

feat: the import-users command and import action will now return details of the import in terms of the number of successful imports and the number of failures. This was void before.