### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ use Bentonow\BentoLaravel\DataTransferObjects\EventData;
 
 $data = collect([
   new EventData(
-    type: "$completed_onboarding",
+    type: '$completed_onboarding',
     email: "user@example.com",
     fields: [
       "first_name" => "John",


### PR DESCRIPTION
Changed the Event Tracking example so it has single quotes instead of double, so PHP doesn't think it's a variable.
