### PR TITLE
Add approved to create broadcasts

### DIFF
--- a/src/DataTransferObjects/CreateBroadcastData.php
+++ b/src/DataTransferObjects/CreateBroadcastData.php
@@ -18,6 +18,7 @@ class CreateBroadcastData
         public readonly string $exclusive_tags,
         public readonly string $segment_id,
         public readonly int $batch_size_per_hour,
+        public readonly int $approved = 0,
     ) {}
 
     public function __toArray(): array
@@ -32,6 +33,7 @@ class CreateBroadcastData
             'exclusive_tags' => $this->exclusive_tags,
             'segment_id' => $this->segment_id,
             'batch_size_per_hour' => $this->batch_size_per_hour,
+            'approved' => $this->approved,
         ];
     }
 }


### PR DESCRIPTION
This adds the `approved` option to the create broadcasts endpoint. 
https://docs.bentonow.com/broadcasts#create-broadcasts

Since the docs say: 

> We STRONGLY recommend you only add this key after you've done a few test requests and have sent those manually.

I figured it shouldn't be documented in the readme and just default to no. 