### PR TITLE
Add support for Saloon v4

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,7 @@
   ],
   "require": {
     "php": ">=8.2",
-    "saloonphp/saloon": "^v3.11.2"
+    "saloonphp/saloon": "^3.11.2 || ^4.0"
   },
   "require-dev": {
     "laravel/pint": "^v1.21.2",


### PR DESCRIPTION
## Summary

Saloon v4.0.0 was released with important security fixes:

- **CVE-2026-33183** — Fixture path traversal
- **CVE-2026-33182** — SSRF via absolute URL
- **CVE-2026-33942** — Unsafe deserialization

This PR widens the `saloonphp/saloon` version constraint from `^v3.11.2` to `^3.11.2 || ^4.0`, allowing consumers to upgrade to Saloon v4 and get these security patches.

## Why no code changes are needed

None of the breaking changes in Saloon v4 affect this SDK:

- **`AccessTokenAuthenticator` removal** — This SDK uses `BasicAuthenticator`, which is unchanged.
- **Absolute URL endpoint restriction** — All requests in this SDK use relative endpoints.
- **Fixture path validation** — No unusual fixture names are used.

The constraint change is the only modification required.

Closes #34