### PR TITLE
Ability to change recipient of test email

### DIFF
--- a/src/Console/TestCommand.php
+++ b/src/Console/TestCommand.php
@@ -31,17 +31,21 @@ class TestCommand extends Command
             return self::FAILURE;
         }
 
-        $this->info('Sending test email to '.$fromAddress.'...');
+        $recipient = $this->input?->isInteractive()
+            ? $this->ask('Where should the test email be sent?', $fromAddress)
+            : $fromAddress;
+
+        $this->info('Sending test email to '.$recipient.'...');
 
         try {
-            Mail::html('<p>This is a test email from your Laravel application using Bento transport.</p>', function (Message $message) use ($fromAddress) {
-                $message->to($fromAddress)
+            Mail::html('<p>This is a test email from your Laravel application using Bento transport.</p>', function (Message $message) use ($recipient) {
+                $message->to($recipient)
                     ->subject('Bento Test Email')
                     ->text('This is a test email from your Laravel application using Bento transport.');
             });
 
             $this->info('Test email sent successfully! ✨');
-            $this->line('Please check your inbox at '.$fromAddress);
+            $this->line('Please check your inbox at '.$recipient);
 
             return self::SUCCESS;
         } catch (\Exception $e) {

--- a/tests/Feature/TestCommandTest.php
+++ b/tests/Feature/TestCommandTest.php
@@ -100,3 +100,30 @@ it('sends the test email when configuration is valid', function () {
         ->toContain('Test email sent successfully! ✨')
         ->toContain('Please check your inbox at sender@example.com');
 });
+
+it('prompts for the recipient when interactive, defaulting to the from address', function () {
+    config([
+        'mail.default' => 'bento',
+        'mail.from.address' => 'sender@example.com',
+    ]);
+
+    Mail::shouldReceive('html')
+        ->once()
+        ->with(
+            '<p>This is a test email from your Laravel application using Bento transport.</p>',
+            Mockery::type('callable')
+        )
+        ->andReturnUsing(function (string $html, callable $callback) {
+            $message = Mockery::mock(Message::class);
+            $message->shouldReceive('to')->once()->with('custom@example.com')->andReturnSelf();
+            $message->shouldReceive('subject')->once()->with('Bento Test Email')->andReturnSelf();
+            $message->shouldReceive('text')->once()->andReturnSelf();
+
+            $callback($message);
+        });
+
+    $this->artisan('bento:test')
+        ->expectsQuestion('Where should the test email be sent?', 'custom@example.com')
+        ->expectsOutputToContain('Sending test email to custom@example.com...')
+        ->assertExitCode(Command::SUCCESS);
+});


### PR DESCRIPTION
This PR adds the ability to change the recipient of the test email sent by the `bento:test` command.

I recently set up Bento on a client project, ran `bento:test`, and realised the test email had been sent to the client's own inbox (they're configured as the from address in the `.env`).

To avoid that, the command now prompts for the recipient before sending, defaulting to the configured from address. You can accept the default by hitting enter, or type a different address.

When the command isn't interactive (e.g. run through a hosting provider's UI rather than over SSH), the prompt is skipped and the command behaves exactly as it does today.

<img width="1358" height="624" alt="CleanShot 2026-07-04 at 08 47 26@2x" src="https://github.com/user-attachments/assets/99179d3d-b220-4fbf-8449-756f5c3798da" />
